### PR TITLE
Publish to npm in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,3 +15,6 @@ jobs:
     - run: npm test
       env:
         CI: true
+    - uses: JS-DevTools/npm-publish@v1
+      with:
+        token: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
This will publish a new package to NPM once the version in package.json changes.

Prereqisite: Provide `NPM_TOKEN` in repo secrets