### PR TITLE
fix for assigning dref to fs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ build
 isolate-*
 .clinic
 unit-test/
+.idea
+output

--- a/packages/runtime/src/statements/assign.ts
+++ b/packages/runtime/src/statements/assign.ts
@@ -1,9 +1,9 @@
-import {FieldSymbol, Structure} from "../types";
+import {DataReference, FieldSymbol, Structure} from "../types";
 import {ICharacter} from "../types/_character";
 import {INumeric} from "../types/_numeric";
 
 export interface IAssignInput {
-  source: INumeric | ICharacter | Structure,
+  source: INumeric | ICharacter | Structure|DataReference,
   target: FieldSymbol,
   component?: string | ICharacter,
 }
@@ -11,7 +11,7 @@ export interface IAssignInput {
 export function assign(input: IAssignInput) {
 
   if (input.component) {
-    if (input.source instanceof FieldSymbol) {
+    if (input.source instanceof FieldSymbol || input.source instanceof DataReference) {
       input.source = input.source.getPointer() as any;
       assign(input);
       return;

--- a/packages/transpiler/src/expressions/source.ts
+++ b/packages/transpiler/src/expressions/source.ts
@@ -49,7 +49,7 @@ export class SourceTranspiler implements IExpressionTranspiler {
         } else if (c.get() instanceof Expressions.ComponentChain) {
           ret = "(" + ret + ").get()." + new ComponentChainTranspiler().transpile(c, traversal);
         } else if (c.get() instanceof Expressions.Dereference) {
-          ret = "(" + ret + ").get()";
+          ret = "(" + ret + ").getPointer()";
         } else {
           ret += "SourceUnknown-" + c.get().constructor.name;
         }

--- a/test/statements/assign.ts
+++ b/test/statements/assign.ts
@@ -135,4 +135,19 @@ ENDLOOP.`;
     expect(abap.console.get()).to.equal("ABCD");
   });
 
+  it("ASSIGN by with field symbol", async () => {
+    const code = `
+      DATA lv_test TYPE string VALUE 'ABCD'.
+      DATA lv_test_ref TYPE REF TO data.
+      GET REFERENCE OF lv_test INTO lv_test_ref.
+      FIELD-SYMBOLS <lv_test> TYPE string.
+      ASSIGN lv_test_ref->* TO <lv_test>.
+      WRITE: / <lv_test>.
+    `;
+    const js = await run(code);
+    const f = new AsyncFunction("abap", js);
+    await f(abap);
+    expect(abap.console.get()).to.equal("ABCD");
+  });
+
 });


### PR DESCRIPTION
a partial fix to https://github.com/abaplint/transpiler/issues/409
ensuring that the assignment of data reference to field symbols works - for example in the statement like this
```abap
  DATA lv_test TYPE string VALUE 'ABCD'.
  DATA lv_test_ref TYPE REF TO data.
  GET REFERENCE OF lv_test INTO lv_test_ref.
  FIELD-SYMBOLS <lv_test> TYPE string.
  ASSIGN lv_test_ref->* TO <lv_test>.
  WRITE: / <lv_test>.
```