### PR TITLE
Adds context propagation for modify and insert statements where table is inferred

### DIFF
--- a/packages/transpiler/src/expressions/type_name_or_infer.ts
+++ b/packages/transpiler/src/expressions/type_name_or_infer.ts
@@ -11,6 +11,12 @@ export class TypeNameOrInfer implements IExpressionTranspiler {
     const type = traversal.lookupInferred(node, scope);
 
     if (type === undefined) {
+        if (node.concatTokens() === "#") {
+      const sqlType = traversal.getSQLInferredType();
+      if (sqlType !== undefined) {
+        return sqlType;
+      }
+    }
       throw new Error("TypeNameOrInfer, type not found: " + node.concatTokens() + ", " + traversal.getCurrentObject().getName() + " line " + node.getFirstToken().getStart().getRow());
     }
 

--- a/packages/transpiler/src/statements/insert_database.ts
+++ b/packages/transpiler/src/statements/insert_database.ts
@@ -23,7 +23,7 @@ export class InsertDatabaseTranspiler implements IStatementTranspiler {
 
     const from = node.findExpressionAfterToken("FROM");
     if (from && from.get() instanceof abaplint.Expressions.SQLSource) {
-      const tvalues = traversal.traverse(from);
+      const tvalues = traversal.traverseWithTableContext(dbtab.concatTokens(), from);
       options.push(`"values": ` + tvalues.getCode());
     }
 

--- a/packages/transpiler/src/statements/modify_database.ts
+++ b/packages/transpiler/src/statements/modify_database.ts
@@ -23,7 +23,7 @@ export class ModifyDatabaseTranspiler implements IStatementTranspiler {
 
     const from = node.findExpressionAfterToken("FROM");
     if (from && from.get() instanceof abaplint.Expressions.SQLSource) {
-      const tvalues = traversal.traverse(from);
+      const tvalues = traversal.traverseWithTableContext(dbtab.concatTokens(), from);
       options.push(`"values": ` + tvalues.getCode());
     }
 

--- a/packages/transpiler/src/traversal.ts
+++ b/packages/transpiler/src/traversal.ts
@@ -130,11 +130,6 @@ export class Traversal {
     return undefined;
   }
 
-
-  public setSQLInferredType(type: abaplint.AbstractType): void {
-    this.sqlInferredType = type;
-  }
-
   public getSQLInferredType(): abaplint.AbstractType | undefined {
     return this.sqlInferredType;
   }

--- a/packages/transpiler/src/traversal.ts
+++ b/packages/transpiler/src/traversal.ts
@@ -15,6 +15,7 @@ export class Traversal {
   private readonly spaghetti: abaplint.ISpaghettiScope;
   private readonly file: abaplint.ABAPFile;
   private readonly obj: abaplint.ABAPObject;
+  private sqlInferredType: abaplint.AbstractType | undefined;
   public readonly reg: abaplint.IRegistry;
   public readonly options: ITranspilerOptions | undefined;
 
@@ -128,6 +129,23 @@ export class Traversal {
 
     return undefined;
   }
+
+
+  public setSQLInferredType(type: abaplint.AbstractType): void {
+    this.sqlInferredType = type;
+  }
+
+  public getSQLInferredType(): abaplint.AbstractType | undefined {
+    return this.sqlInferredType;
+  }
+
+  public traverseWithTableContext(tableName: string, expressionNode: abaplint.Nodes.ExpressionNode): Chunk {
+    const tabl = this.reg.getObject("TABL", tableName) as abaplint.Objects.Table | undefined;
+    this.sqlInferredType = tabl?.parseType(this.reg);
+    const result = this.traverse(expressionNode);
+    this.sqlInferredType = undefined;
+    return result;
+}
 
   public getInterfaceDefinition(token: abaplint.Token): abaplint.IInterfaceDefinition | undefined {
     let scope = this.findCurrentScopeByToken(token);

--- a/test/database.ts
+++ b/test/database.ts
@@ -561,7 +561,7 @@ ASSERT sy-subrc = 0.`;
       {filename: "t100.tabl.xml", contents: tabl_t100xml},
       {filename: "zag_unit_test.msag.xml", contents: msag_zag_unit_test}];
     await runAllDatabases(abap, files, () => {
-      expect(abap.console.get().trim).to.equal("0inserted inline");
+      expect(abap.console.get().trim()).to.equal("0inserted inline");
     }, {snowflake: false});
   });
 

--- a/test/database.ts
+++ b/test/database.ts
@@ -544,6 +544,27 @@ ASSERT sy-subrc = 0.`;
     });
   });
 
+  it("INSERT with VALUE # inline", async () => {
+    const code = `
+      INSERT t100 FROM @( VALUE #( sprsl = 'E' 
+                                  arbgb = 'INSERT_TEST' 
+                                  msgnr = '999' 
+                                  text = 'inserted inline' ) ).
+      WRITE sy-subrc.
+      
+      " Read it back to verify
+      DATA ls_check TYPE t100.
+      SELECT SINGLE * FROM t100 INTO @ls_check WHERE arbgb = 'INSERT_TEST'.
+      WRITE ls_check-text.`;
+    const files = [
+      {filename: "zfoobar.prog.abap", contents: code},
+      {filename: "t100.tabl.xml", contents: tabl_t100xml},
+      {filename: "zag_unit_test.msag.xml", contents: msag_zag_unit_test}];
+    await runAllDatabases(abap, files, () => {
+      expect(abap.console.get().trim).to.equal("0inserted inline");
+    }, {snowflake: false});
+  });
+
   it("INSERT FROM, escape ampersand", async () => {
     const code = `
     DATA ls_t100 TYPE t100.
@@ -754,6 +775,27 @@ ASSERT sy-subrc = 0.`;
       expect(abap.console.get()).to.equal("00");
     }, {snowflake: false});
   });
+
+  it("MODIFY with VALUE # inline", async () => {
+  const code = `
+    MODIFY t100 FROM @( VALUE #( sprsl = 'E' 
+                                 arbgb = 'TEST' 
+                                 msgnr = '001' 
+                                 text = 'inline value' ) ).
+    WRITE sy-subrc.
+    
+    " Now read it back to verify it worked
+    DATA ls_check TYPE t100.
+    SELECT SINGLE * FROM t100 INTO @ls_check WHERE arbgb = 'TEST'.
+    WRITE ls_check-text.`;
+  const files = [
+    {filename: "zfoobar.prog.abap", contents: code},
+    {filename: "t100.tabl.xml", contents: tabl_t100xml},
+    {filename: "zag_unit_test.msag.xml", contents: msag_zag_unit_test}];
+  await runAllDatabases(abap, files, () => {
+    expect(abap.console.get().trim()).to.equal("0inline value");
+  }, {snowflake: false});
+});
 
   it("INSERT FROM TABLE", async () => {
     const code = `

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,7 @@
     "alwaysStrict": true,
     "target": "es2022",
     "sourceMap": true,
-    "types": ["mocha", "node"]
+    "baseUrl": "."
   },
   "filesGlob": [
     "./test/**/*.ts",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,7 @@
     "alwaysStrict": true,
     "target": "es2022",
     "sourceMap": true,
-    "baseUrl": "."
+    "types": ["mocha", "node"]
   },
   "filesGlob": [
     "./test/**/*.ts",


### PR DESCRIPTION
Adds the ability to transpile SQL statements where the type is inferred in statements like:
```
MODIFY /my/custom/table FROM @( VALUE #(
          my_field1     = my_value1
          my_field2      = my_value2
        ) )
```

