### PR TITLE
fix PERFORM CHANGING dropping arguments

### DIFF
--- a/packages/transpiler/src/statements/perform.ts
+++ b/packages/transpiler/src/statements/perform.ts
@@ -72,7 +72,7 @@ export class PerformTranspiler implements IStatementTranspiler {
       }
 
       index = 0;
-      for (const c of node.findDirectExpression(abaplint.Expressions.PerformChanging)?.findDirectExpressions(abaplint.Expressions.Source) || []) {
+      for (const c of node.findDirectExpression(abaplint.Expressions.PerformChanging)?.findDirectExpressions(abaplint.Expressions.Target) || []) {
         const name = def?.getChangingParameters()[index].getName().toLowerCase();
         if (name === undefined) {
           continue;

--- a/test/code_structure/form.ts
+++ b/test/code_structure/form.ts
@@ -42,4 +42,36 @@ describe("Running code structure - FORM / PERFORM", () => {
     expect(abap.console.get()).to.equal("hello");
   });
 
+  it("CHANGING parameter", async () => {
+    const code = `
+    FORM double CHANGING cv_val TYPE i.
+      cv_val = cv_val * 2.
+    ENDFORM.
+
+    START-OF-SELECTION.
+      DATA lv_int TYPE i VALUE 21.
+      PERFORM double CHANGING lv_int.
+      WRITE / lv_int.`;
+    const js = await run(code);
+    const f = new AsyncFunction("abap", js);
+    await f(abap);
+    expect(abap.console.get()).to.equal("42");
+  });
+
+  it("USING and CHANGING together", async () => {
+    const code = `
+    FORM concat USING iv_in TYPE string CHANGING cv_out TYPE string.
+      CONCATENATE cv_out iv_in INTO cv_out.
+    ENDFORM.
+
+    START-OF-SELECTION.
+      DATA lv_str TYPE string VALUE 'foo'.
+      PERFORM concat USING 'bar' CHANGING lv_str.
+      WRITE / lv_str.`;
+    const js = await run(code);
+    const f = new AsyncFunction("abap", js);
+    await f(abap);
+    expect(abap.console.get()).to.equal("foobar");
+  });
+
 });


### PR DESCRIPTION
Every CHANGING argument of a PERFORM was silently dropped — the FORM received an empty INPUT object, so changes never reached the caller.

Cause: `PerformChanging` wraps `Target` expressions in the abaplint grammar, but the transpiler collected `Source` ones, so the loop never matched anything.

Fix: collect `Target` expressions, mirroring the `IN PROGRAM` branch above.

Added two runtime tests (plain CHANGING, USING + CHANGING together): both fail before the fix and pass after.

Closes #1478