### PR TITLE
runtime: DELETE WHERE sets sy-subrc

### DIFF
--- a/packages/runtime/src/statements/delete_internal.ts
+++ b/packages/runtime/src/statements/delete_internal.ts
@@ -97,6 +97,7 @@ export async function deleteInternal(target: Table | HashedTable | FieldSymbol, 
     return;
   }
 
+  let deleted = 0;
   for await (const i of loop(target)) {
     index = abap.builtin.sy.get().tabix.get() - 1;
 
@@ -108,6 +109,7 @@ export async function deleteInternal(target: Table | HashedTable | FieldSymbol, 
         } else {
           target.deleteIndex(index);
         }
+        deleted++;
       }
     } else if (options?.index && options.index.get() === index) {
       target.deleteIndex(options.index.get() - 1);
@@ -117,5 +119,9 @@ export async function deleteInternal(target: Table | HashedTable | FieldSymbol, 
     } else if (options?.from && options.from.get() <= index + 1) {
       target.deleteIndex(index);
     }
+  }
+
+  if (options?.where) {
+    abap.builtin.sy.get().subrc.set(deleted > 0 ? 0 : 4);
   }
 }

--- a/test/statements/delete_internal.ts
+++ b/test/statements/delete_internal.ts
@@ -26,6 +26,20 @@ describe("Running statements - DELETE internal", () => {
     await f(abap);
   });
 
+  it("DELETE WHERE sets sy-subrc", async () => {
+    const code = `
+      DATA table TYPE STANDARD TABLE OF i.
+      APPEND 1 TO table.
+      APPEND 2 TO table.
+      DELETE table WHERE table_line = 1.
+      ASSERT sy-subrc = 0.
+      DELETE table WHERE table_line = 1.
+      ASSERT sy-subrc = 4.`;
+    const js = await run(code);
+    const f = new AsyncFunction("abap", js);
+    await f(abap);
+  });
+
   it("DELETE from table INDEX 1", async () => {
     const code = `
       DATA foo TYPE STANDARD TABLE OF i WITH DEFAULT KEY.


### PR DESCRIPTION
`DELETE itab WHERE ...` now sets sy-subrc to 0 when at least one row was deleted and to 4 otherwise, matching SAP behavior. Previously sy-subrc kept its prior value, so existence checks after DELETE WHERE always saw 0.

Found while implementing `cl_abap_zip=>delete` in open-abap-core.

Test included: fails before the fix, passes after.