### PR TITLE
SELECT ... INTO TABLE clears the target when nothing is found

### DIFF
--- a/packages/runtime/src/statements/select.ts
+++ b/packages/runtime/src/statements/select.ts
@@ -19,6 +19,12 @@ export async function select(target: Structure | Table | HashedTable | FieldSymb
   }
 
   if (rows.length === 0) {
+    // INTO TABLE always initializes the target, also when nothing is found;
+    // a work area is left untouched instead
+    if (runtimeOptions?.appending !== true
+        && (target instanceof Table || target instanceof HashedTable)) {
+      target.clear();
+    }
     abap.builtin.sy.get().dbcnt.set(0);
     abap.builtin.sy.get().subrc.set(4);
     return;

--- a/test/database.ts
+++ b/test/database.ts
@@ -368,13 +368,17 @@ describe("Top level tests, Database", () => {
     SELECT SINGLE * FROM t100 INTO row.
     ASSERT row-arbgb IS NOT INITIAL.
     SELECT SINGLE * FROM t100 INTO row WHERE arbgb = 'NOT_THERE'.
-    WRITE row-arbgb.`;
+    IF row-arbgb = 'ZAG_UNIT_TEST'.
+      WRITE 'kept'.
+    ELSE.
+      WRITE 'cleared'.
+    ENDIF.`;
     const files = [
       {filename: "zfoobar.prog.abap", contents: code},
       {filename: "t100.tabl.xml", contents: tabl_t100xml},
       {filename: "zag_unit_test.msag.xml", contents: msag_zag_unit_test}];
     await runAllDatabases(abap, files, () => {
-      expect(abap.console.get()).to.equal("ZAG_UNIT_TEST");
+      expect(abap.console.get()).to.equal("kept");
     });
   });
 

--- a/test/database.ts
+++ b/test/database.ts
@@ -346,6 +346,38 @@ describe("Top level tests, Database", () => {
     });
   });
 
+  it("SELECT INTO TABLE, empty result clears the target", async () => {
+    const code = `
+    DATA tab TYPE STANDARD TABLE OF t100 WITH DEFAULT KEY.
+    SELECT * FROM t100 INTO TABLE tab.
+    ASSERT lines( tab ) = 2.
+    SELECT * FROM t100 INTO TABLE tab WHERE arbgb = 'NOT_THERE'.
+    WRITE lines( tab ).`;
+    const files = [
+      {filename: "zfoobar.prog.abap", contents: code},
+      {filename: "t100.tabl.xml", contents: tabl_t100xml},
+      {filename: "zag_unit_test.msag.xml", contents: msag_zag_unit_test}];
+    await runAllDatabases(abap, files, () => {
+      expect(abap.console.get()).to.equal("0");
+    });
+  });
+
+  it("SELECT SINGLE, no hit leaves the work area untouched", async () => {
+    const code = `
+    DATA row TYPE t100.
+    SELECT SINGLE * FROM t100 INTO row.
+    ASSERT row-arbgb IS NOT INITIAL.
+    SELECT SINGLE * FROM t100 INTO row WHERE arbgb = 'NOT_THERE'.
+    WRITE row-arbgb.`;
+    const files = [
+      {filename: "zfoobar.prog.abap", contents: code},
+      {filename: "t100.tabl.xml", contents: tabl_t100xml},
+      {filename: "zag_unit_test.msag.xml", contents: msag_zag_unit_test}];
+    await runAllDatabases(abap, files, () => {
+      expect(abap.console.get()).to.equal("ZAG_UNIT_TEST");
+    });
+  });
+
   it("SELECT INTO TABLE, ORDER BY PRIMARY KEY", async () => {
     const code = `
     DATA tab TYPE STANDARD TABLE OF t100 WITH DEFAULT KEY.


### PR DESCRIPTION
An empty result returns before the clearing block, so the internal table keeps the rows of the previous SELECT. In SAP the target of `INTO TABLE` is always initialized.

This is a silent data bug rather than a crash: a loop that selects per key fills later iterations with the previous key's rows. It was found in a report where entities without any records inherited the rows of the entity processed before them.

A work area (`SELECT SINGLE ... INTO wa`) keeps its content on SAP, so the clear is limited to `Table`/`HashedTable` targets.

Two testcases included — one per behaviour.

Note: locally the new tests fail only in the Postgres/Snowflake legs of `runAllDatabases` (no Docker here), together with the other database tests; the sqlite path was verified separately end to end.