### PR TITLE
Dynamic ASSIGN through a missing component is sy-subrc 4, not a TypeError

### DIFF
--- a/packages/runtime/src/statements/assign.ts
+++ b/packages/runtime/src/statements/assign.ts
@@ -37,6 +37,13 @@ export function assign(input: IAssignInput) {
         for (const s of split) {
           const upperS = s.toUpperCase().trimEnd();
           if (upperS === "*") {
+            if (!(input.dynamicSource instanceof DataReference)
+                && !(input.dynamicSource instanceof FieldSymbol)) {
+              // an earlier segment resolved to nothing, or to something that has
+              // no address, so the name cannot be followed: sy-subrc 4
+              abap.builtin.sy.get().subrc.set(4);
+              return;
+            }
             // @ts-ignore
             input.dynamicSource = input.dynamicSource.dereference();
           } else if (upperS === "TABLE_LINE" && input.dynamicSource instanceof DataReference) {

--- a/test/statements/assign.ts
+++ b/test/statements/assign.ts
@@ -1082,4 +1082,36 @@ WRITE / sy-subrc.`;
     expect(abap.console.getTrimmed()).to.equal("0\n4");
   });
 
+  it("ASSIGN dynamic, dereference after a component that does not exist", async () => {
+    const code = `
+CLASS lcl DEFINITION.
+  PUBLIC SECTION.
+    DATA ref TYPE REF TO i.
+ENDCLASS.
+
+CLASS lcl IMPLEMENTATION.
+ENDCLASS.
+
+FORM run.
+  DATA obj TYPE REF TO lcl.
+  FIELD-SYMBOLS <fs> TYPE any.
+  CREATE OBJECT obj.
+  GET REFERENCE OF 42 INTO obj->ref.
+
+  ASSIGN ('OBJ->REF->*') TO <fs>.
+  WRITE / sy-subrc.
+  WRITE / <fs>.
+
+  ASSIGN ('OBJ->NOT_THERE->*') TO <fs>.
+  WRITE / sy-subrc.
+ENDFORM.
+
+START-OF-SELECTION.
+  PERFORM run.`;
+    const js = await run(code);
+    const f = new AsyncFunction("abap", js);
+    await f(abap);
+    expect(abap.console.getTrimmed()).to.equal("0\n42\n4");
+  });
+
 });


### PR DESCRIPTION
## The problem

On a system a dynamic `ASSIGN (name) TO <fs>` whose path cannot be followed sets
`sy-subrc = 4` and leaves the field symbol unassigned — whichever segment fails.
Transpiled, one segment kind throws instead:

```abap
ASSIGN ('OBJ->NOT_THERE->*') TO <fs>.
```

```
TypeError: Cannot read properties of undefined (reading 'dereference')
    at Statements.assign (packages/runtime/src/statements/assign.ts:41:55)
```

A JavaScript TypeError is not something an ABAP `CATCH cx_root` can reach, so the
program dies where a server would have carried on with `sy-subrc = 4`.

## Why

`assign` walks the `->`/`-` segments. For a component the object does not have it
stores `undefined` and continues — which is fine, because every following segment
kind copes with that already:

- a further component reads `sourceContainer?.get()` as `undefined` and answers
  subrc 4,
- `TABLE_LINE` fails its `instanceof DataReference` guard,
- and a walk that ends there falls through to the subrc 4 at the end of the block.

The one exception is `*`, which calls `.dereference()` on the source unguarded.

## The change

Only `DataReference` and `FieldSymbol` implement `dereference()`, so the guard is
an instanceof pair — anything else arriving at a `*` segment has no address to
follow, which is the same subrc 4:

```ts
if (upperS === "*") {
  if (!(input.dynamicSource instanceof DataReference)
      && !(input.dynamicSource instanceof FieldSymbol)) {
    // an earlier segment resolved to nothing, or to something that has
    // no address, so the name cannot be followed: sy-subrc 4
    abap.builtin.sy.get().subrc.set(4);
    return;
  }
  // @ts-ignore
  input.dynamicSource = input.dynamicSource.dereference();
}
```

Nothing that resolved before can take the new branch: a source that reached
`.dereference()` successfully was necessarily one of those two types. So no
working program changes behaviour, and the emitted JavaScript is untouched — this
is a runtime-only change.

## Tests

One test, both halves in one program so the guard cannot pass by disabling the
feature: `OBJ->REF->*` still yields `0` / `42`, `OBJ->NOT_THERE->*` yields `4`.

Without the fix it reproduces the TypeError above; with it, the ASSIGN suite goes
52 → 53 passing. Whole suite 2156 passing / 0 failing (excluding the database and
git-clone tests, which need Postgres and network here), `npm run lint` clean.

## Where this bites

Found in abap2UI5, which resolves every attribute of a persisted draft by such a
dynamic name. A host that swapped a `REF TO object` sub-app for an instance of
another class between two roundtrips leaves rows that resolve to nothing — a real
server skips them, transpiled the whole restore died. It has been carried as a
local patch of the installed `@abaplint/runtime` since then, running against
~630 apps.