### PR TITLE
Character literal length: strip the enclosing quotes before counting

### DIFF
--- a/packages/transpiler/src/expressions/constant.ts
+++ b/packages/transpiler/src/expressions/constant.ts
@@ -85,8 +85,10 @@ export class ConstantTranspiler implements IExpressionTranspiler {
   }
 
   private handleCharacter(res: string): string {
-    const foo = res.replace(/''/g, "'");
-    let length = foo.length - 2;
+    // length of the value: strip the enclosing quotes first, an escaped
+    // quote ('') inside counts as one character and must not merge with them
+    const inner = res.substring(1, res.length - 1).replace(/''/g, "'");
+    let length = inner.length;
     if (length <= 0) {
       // note: Characters cannot have length = zero, 1 is minimum
       length = 1;

--- a/test/expressions/character_literal.ts
+++ b/test/expressions/character_literal.ts
@@ -1,0 +1,52 @@
+import {expect} from "chai";
+import {ABAP, MemoryConsole} from "../../packages/runtime/src";
+import {AsyncFunction, runFiles} from "../_utils";
+
+let abap: ABAP;
+
+async function run(contents: string) {
+  return runFiles(abap, [{filename: "zfoobar.prog.abap", contents}]);
+}
+
+describe("Running expressions - Character literals", () => {
+
+  beforeEach(async () => {
+    abap = new ABAP({console: new MemoryConsole()});
+  });
+
+  it("escaped quote inside a literal", async () => {
+    const code = `
+      DATA lv TYPE c LENGTH 5.
+      lv = 'a''b'.
+      WRITE strlen( lv ).
+      WRITE lv.`;
+    const js = await run(code);
+    const f = new AsyncFunction("abap", js);
+    await f(abap);
+    expect(abap.console.get()).to.equal("3a'b  ");
+  });
+
+  it("literal of two quotes has length two", async () => {
+    const code = `
+      DATA lv TYPE string.
+      lv = ''''''.
+      WRITE strlen( lv ).`;
+    const js = await run(code);
+    const f = new AsyncFunction("abap", js);
+    await f(abap);
+    expect(abap.console.get()).to.equal("2");
+  });
+
+  it("REPLACE with a two-quote pattern", async () => {
+    const code = `
+      DATA lv TYPE string.
+      lv = \`x''y\`.
+      REPLACE ALL OCCURRENCES OF '''''' IN lv WITH ''''.
+      WRITE lv.`;
+    const js = await run(code);
+    const f = new AsyncFunction("abap", js);
+    await f(abap);
+    expect(abap.console.get()).to.equal("x'y");
+  });
+
+});


### PR DESCRIPTION
`handleCharacter` computed the length after collapsing `''` on the whole token, so the enclosing quotes merged with escaped quotes: a literal of two quotes (`''''''`) came out as `abap.CharacterFactory.get(1, '\'\'')`, a single quote, and

```abap
REPLACE ALL OCCURRENCES OF '''''' IN lv WITH ''''.
```

was a no-op (the pattern degenerated to `'`). The value itself was right, only the length was off.

Count on the inner text instead. Tests: an escaped quote inside a `c` literal (length and padded output), a literal of two quotes has `strlen` 2, and the `REPLACE` case above yields `x'y`.

Found while running SEGW OData code through the transpiler (key predicates and `$filter` literals un-double their quotes).