### PR TITLE
FOR ALL ENTRIES: de-duplicate by the selected columns, not the DB key

### DIFF
--- a/packages/transpiler/src/statements/select.ts
+++ b/packages/transpiler/src/statements/select.ts
@@ -138,10 +138,11 @@ export class SelectTranspiler implements IStatementTranspiler {
       select = select.replace(new RegExp(" " + escapeRegExp(faeTranspiled!), "g"), " " + unique);
       select = select.replace(unique + ".get().table_line.get()", unique + ".get()");  // there can be only one?
 
-      let by = `Object.keys(${target}.getRowType().get())`;
-      if (keys.length > 0) {
-        by = JSON.stringify(keys);
-      }
+      // FOR ALL ENTRIES removes duplicate rows from the result: duplicates of
+      // the selected columns, so de-duplicate by the target's components. The
+      // DB key alone is wrong for projections (INTO CORRESPONDING FIELDS
+      // without the key fields crashed on the missing component names)
+      const by = `Object.keys(${target}.getRowType().get())`;
 
       const code = `if (${faeTranspiled}.array().length === 0) {
   throw new Error("FAE, todo, empty table");

--- a/test/database.ts
+++ b/test/database.ts
@@ -1582,6 +1582,31 @@ WRITE sy-dbcnt.`;
     });
   });
 
+  it("FOR ALL ENTRIES, projection without the key fields", async () => {
+    const code = `
+DATA: BEGIN OF ls_res,
+        arbgb TYPE t100-arbgb,
+        text  TYPE t100-text,
+      END OF ls_res.
+DATA lt_res LIKE STANDARD TABLE OF ls_res WITH DEFAULT KEY.
+DATA input TYPE STANDARD TABLE OF t100-arbgb WITH DEFAULT KEY.
+APPEND 'ZAG_UNIT_TEST' TO input.
+APPEND 'ZAG_UNIT_TEST' TO input.
+SELECT arbgb text FROM t100
+  INTO CORRESPONDING FIELDS OF TABLE lt_res
+  FOR ALL ENTRIES IN input
+  WHERE sprsl = 'E'
+  AND arbgb = input-table_line.
+WRITE sy-dbcnt.`;
+    const files = [
+      {filename: "zfoobar.prog.abap", contents: code},
+      {filename: "t100.tabl.xml", contents: tabl_t100xml},
+      {filename: "zag_unit_test.msag.xml", contents: msag_zag_unit_test}];
+    await runAllDatabases(abap, files, () => {
+      expect(abap.console.get()).to.equal("2");
+    });
+  });
+
   it("SELECT LOOP CORRESPONDING", async () => {
     const code = `
 DATA: BEGIN OF res,


### PR DESCRIPTION
`FOR ALL ENTRIES` removes duplicate rows from the result set: rows that are identical in the *selected* columns. The generated code sorted and de-duplicated the target table by the database table's key instead, which crashes as soon as the target is a projection without those fields:

```abap
DATA: BEGIN OF ls_res, arbgb TYPE t100-arbgb, text TYPE t100-text, END OF ls_res.
DATA lt_res LIKE STANDARD TABLE OF ls_res WITH DEFAULT KEY.
SELECT arbgb text FROM t100 INTO CORRESPONDING FIELDS OF TABLE lt_res
  FOR ALL ENTRIES IN input WHERE sprsl = 'E' AND arbgb = input-table_line.
```

```
Error: sort compare, wrong component name, sprsl
```

This change de-duplicates by the target row's components in every case (`Object.keys(target.getRowType().get())`, which the code already used when the table had no key). For `SELECT *` that is the previous behaviour since the key is part of the row.

Test: a two-field projection with a duplicated driver entry expects `sy-dbcnt` 2 (the two distinct rows), where it crashed before.

Seen in hand-written SEGW data providers, where FAE into a projection structure is the common shape.