### PR TITLE
CREATE DATA TYPE STANDARD TABLE OF <ddic>: import views, honor the TABLE flag

### DIFF
--- a/packages/runtime/src/statements/create_data.ts
+++ b/packages/runtime/src/statements/create_data.ts
@@ -160,7 +160,10 @@ export function createData(target: DataReference | FieldSymbol, options?: ICreat
         target.assign(new DecFloat34());
         break;
       default:
-        if (abap.DDIC[options.typeName.trimEnd()]) {
+        if (abap.DDIC[options.typeName.trimEnd()] && options.table) {
+          // static "TYPE STANDARD TABLE OF <ddic>", same as the dynamic name variant above
+          target.assign(new abap.types.Table(abap.DDIC[options.typeName.trimEnd()].type(), tableOptions));
+        } else if (abap.DDIC[options.typeName.trimEnd()]) {
           target.assign(abap.DDIC[options.typeName.trimEnd()].type().clone());
         } else if (options.typeName.includes("=>")) {
           const [className, typeName] = options.typeName.toUpperCase().split("=>");

--- a/packages/transpiler/src/initialization.ts
+++ b/packages/transpiler/src/initialization.ts
@@ -96,7 +96,8 @@ globalThis.abap = new runtime.ABAP();\n`;
           || obj instanceof abaplint.Objects.Oauth2Profile
           || obj instanceof abaplint.Objects.WebMIME
           || obj instanceof abaplint.Objects.TypePool
-          || obj instanceof abaplint.Objects.TableType) {
+          || obj instanceof abaplint.Objects.TableType
+          || obj instanceof abaplint.Objects.View) {
         list.push(imp(`${escapeNamespaceFilename(obj.getName().toLowerCase())}.${obj.getType().toLowerCase()}`));
       }
     }

--- a/test/_utils.ts
+++ b/test/_utils.ts
@@ -34,7 +34,7 @@ export async function runFiles(abap: ABAP, files: IFile[], options?: ITranspiler
   }
   let pre = "";
   for (const o of res.objects) {
-    if (o.object.type === "TABL" || o.object.type === "TTYP") {
+    if (o.object.type === "TABL" || o.object.type === "TTYP" || o.object.type === "VIEW") {
       pre += o.chunk.getCode() + "\n";
     }
   }

--- a/test/database.ts
+++ b/test/database.ts
@@ -2649,8 +2649,7 @@ ENDLOOP.`;
     }, {snowflake: false});
   });
 
-  it("basic VIEW", async () => {
-    const zview = `<?xml version="1.0" encoding="utf-8"?>
+const zview_xml = `<?xml version="1.0" encoding="utf-8"?>
 <abapGit version="v1.0.0" serializer="LCL_OBJECT_VIEW" serializer_version="v1.0.0">
  <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
   <asx:values>
@@ -2709,7 +2708,7 @@ ENDLOOP.`;
   </asx:values>
  </asx:abap>
 </abapGit>`;
-    const ztabl1 = `<?xml version="1.0" encoding="utf-8"?>
+const ztabl1_xml = `<?xml version="1.0" encoding="utf-8"?>
 <abapGit version="v1.0.0" serializer="LCL_OBJECT_TABL" serializer_version="v1.0.0">
  <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
   <asx:values>
@@ -2753,7 +2752,7 @@ ENDLOOP.`;
   </asx:values>
  </asx:abap>
 </abapGit>`;
-    const ztabl2 = `<?xml version="1.0" encoding="utf-8"?>
+const ztabl2_xml = `<?xml version="1.0" encoding="utf-8"?>
 <abapGit version="v1.0.0" serializer="LCL_OBJECT_TABL" serializer_version="v1.0.0">
  <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
   <asx:values>
@@ -2797,13 +2796,51 @@ ENDLOOP.`;
   </asx:values>
  </asx:abap>
 </abapGit>`;
+
+  it("basic VIEW", async () => {
     const files = [
-      {filename: "zview.view.xml", contents: zview},
-      {filename: "ztabl1.tabl.xml", contents: ztabl1},
-      {filename: "ztabl2.tabl.xml", contents: ztabl2},
+      {filename: "zview.view.xml", contents: zview_xml},
+      {filename: "ztabl1.tabl.xml", contents: ztabl1_xml},
+      {filename: "ztabl2.tabl.xml", contents: ztabl2_xml},
     ];
     await runAllDatabases(abap, files, () => {
 // check that the view was created
+    }, {snowflake: false});
+  });
+
+  it("CREATE DATA, TYPE STANDARD TABLE OF ddic table, SELECT into it", async () => {
+    const code = `
+DATA ref TYPE REF TO data.
+FIELD-SYMBOLS <tab> TYPE STANDARD TABLE.
+CREATE DATA ref TYPE STANDARD TABLE OF t100.
+ASSIGN ref->* TO <tab>.
+SELECT * FROM t100 INTO TABLE <tab>.
+WRITE lines( <tab> ).`;
+    const files = [
+      {filename: "zfoobar.prog.abap", contents: code},
+      {filename: "t100.tabl.xml", contents: tabl_t100xml},
+    ];
+    await runAllDatabases(abap, files, () => {
+      expect(abap.console.get()).to.equal("0");
+    });
+  });
+
+  it("VIEW, CREATE DATA and SELECT into it", async () => {
+    const code = `
+DATA ref TYPE REF TO data.
+FIELD-SYMBOLS <tab> TYPE STANDARD TABLE.
+CREATE DATA ref TYPE STANDARD TABLE OF zview.
+ASSIGN ref->* TO <tab>.
+SELECT * FROM zview INTO TABLE <tab>.
+WRITE lines( <tab> ).`;
+    const files = [
+      {filename: "zfoobar.prog.abap", contents: code},
+      {filename: "zview.view.xml", contents: zview_xml},
+      {filename: "ztabl1.tabl.xml", contents: ztabl1_xml},
+      {filename: "ztabl2.tabl.xml", contents: ztabl2_xml},
+    ];
+    await runAllDatabases(abap, files, () => {
+      expect(abap.console.get()).to.equal("0");
     }, {snowflake: false});
   });
 


### PR DESCRIPTION
`CREATE DATA ref TYPE STANDARD TABLE OF zview.` (static form, DDIC view) fails in a transpiled project, for two independent reasons:

1. **Views are never imported.** `initialization.ts` imports the generated `.tabl.mjs` / `.dtel.mjs` / `.ttyp.mjs` / … files, but not `.view.mjs`, so `abap.DDIC["ZVIEW"]` is never registered and the runtime raises `CREATE DATA, unknown type ZVIEW`. `HandleView` already emits the file; it just was not in the import list.
2. **The runtime ignores `table: true` for static DDIC names.** The `typeName` branch of `createData` assigns the bare structure, so the reference points at a structure and the following `ASSIGN ref->* TO <tab>` (`<tab> TYPE STANDARD TABLE`) raises `ASSIGN_TYPE_CONFLICT`. This affects plain tables too, e.g. `CREATE DATA ref TYPE STANDARD TABLE OF t100.` The dynamic form `CREATE DATA ref TYPE TABLE OF ('T100').` already wraps the row type in a `Table`; the static form now does the same.

Changes:
- `packages/transpiler/src/initialization.ts`: add `abaplint.Objects.View` to the DDIC import list.
- `packages/runtime/src/statements/create_data.ts`: wrap the DDIC type in a `Table` when `table` is set, mirroring the dynamic-name branch.
- `test/_utils.ts`: the harness preloads `VIEW` chunks next to `TABL`/`TTYP`.
- `test/database.ts`: hoist the "basic VIEW" fixtures; two new tests, `CREATE DATA ... OF t100` and `CREATE DATA ... OF zview`, each followed by a `SELECT ... INTO TABLE <tab>`.

Package suites (`packages/transpiler`, `packages/runtime`) and the `database.ts` / `create_data` / `assign` root tests pass locally on sqlite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J7JpA3TGT48zBoix3Ut88s
