### PR TITLE
FOR ALL ENTRIES: empty driving table selects all rows, like ABAP

### DIFF
--- a/packages/transpiler/src/statements/select.ts
+++ b/packages/transpiler/src/statements/select.ts
@@ -62,9 +62,11 @@ export class SelectTranspiler implements IStatementTranspiler {
         where = sqlCond;
       }
     }
+    let whereClause = "";
     if (where) {
-      select += "WHERE " + new SQLCondTranspiler().transpile(where, traversal, table).getCode() + " ";
+      whereClause = "WHERE " + new SQLCondTranspiler().transpile(where, traversal, table).getCode() + " ";
     }
+    select += whereClause;
 
     const groupBy = node.findFirstExpression(abaplint.Expressions.SQLGroupBy);
     if (groupBy) {
@@ -104,6 +106,7 @@ export class SelectTranspiler implements IStatementTranspiler {
         } else {
           const code = new FieldChainTranspiler(true).transpile(chain, traversal).getCode();
           select = select.replace(search, `" + ${code} + "`);
+          whereClause = whereClause.replace(search, `" + ${code} + "`);
         }
       }
     }
@@ -135,6 +138,8 @@ export class SelectTranspiler implements IStatementTranspiler {
       const unique2 = UniqueIdentifier.get();
       const fn = node.findFirstExpression(abaplint.Expressions.SQLForAllEntries)?.findDirectExpression(abaplint.Expressions.SQLSource);
       const faeTranspiled = new SQLSourceTranspiler().transpile(fn!, traversal).getCode();
+      // ABAP semantics: with an empty driving table the whole WHERE condition is ignored
+      const selectEmpty = select.replace(whereClause, "");
       select = select.replace(new RegExp(" " + escapeRegExp(faeTranspiled!), "g"), " " + unique);
       select = select.replace(unique + ".get().table_line.get()", unique + ".get()");  // there can be only one?
 
@@ -144,7 +149,7 @@ export class SelectTranspiler implements IStatementTranspiler {
       }
 
       const code = `if (${faeTranspiled}.array().length === 0) {
-  throw new Error("FAE, todo, empty table");
+  await abap.statements.select(${target}, {select: "${selectEmpty.trim()}"${extra}});
 } else {
   const ${unique2} = ${faeTranspiled}.array();
   ${target}.clear();

--- a/test/database.ts
+++ b/test/database.ts
@@ -611,6 +611,33 @@ ENDSELECT.`;
     });
   });
 
+  it("FOR ALL ENTRIES, empty driving table selects all rows", async () => {
+    const code = `
+DATA lt_all TYPE STANDARD TABLE OF t100 WITH DEFAULT KEY.
+DATA lt_t100 TYPE STANDARD TABLE OF t100 WITH DEFAULT KEY.
+DATA lt_fae TYPE STANDARD TABLE OF t100 WITH DEFAULT KEY.
+
+SELECT * FROM t100 INTO TABLE lt_all.
+ASSERT lines( lt_all ) > 0.
+
+SELECT * FROM t100 INTO TABLE lt_t100
+  FOR ALL ENTRIES IN lt_fae
+  WHERE msgnr = lt_fae-msgnr
+  AND arbgb = 'DOESNOTEXIST'.
+IF lines( lt_t100 ) = lines( lt_all ) AND sy-dbcnt = lines( lt_all ).
+  WRITE 'all'.
+ELSE.
+  WRITE 'nope'.
+ENDIF.`;
+    const files = [
+      {filename: "zfoobar.prog.abap", contents: code},
+      {filename: "t100.tabl.xml", contents: tabl_t100xml},
+      {filename: "zag_unit_test.msag.xml", contents: msag_zag_unit_test}];
+    await runAllDatabases(abap, files, () => {
+      expect(abap.console.get()).to.equal("all");
+    });
+  });
+
   it("FOR ALL ENTRIES, condition not true", async () => {
     const code = `
 DATA lt_t100 TYPE STANDARD TABLE OF t100 WITH DEFAULT KEY.


### PR DESCRIPTION
`SELECT ... FOR ALL ENTRIES IN itab WHERE ...` with an empty `itab` currently throws `FAE, todo, empty table` at runtime.

In ABAP an empty driving table means the **whole WHERE condition is ignored** and every row of the table ends up in the result (the classic FAE trap, but it is the documented semantics and real code relies on it, e.g. "no filter given → return everything" in DPC entity-set reads). This PR makes the generated code follow that: the empty branch runs the same SELECT without its WHERE clause; `sy-dbcnt` is set by the normal select path. Dynamic tokens inside the WHERE are substituted in both variants.

If you would rather keep the hard error to flag suspicious code, an alternative would be a transpiler option; happy to rework it that way.

- `packages/transpiler/src/statements/select.ts`: keep the WHERE clause separately, build the no-WHERE variant for the empty branch.
- `test/database.ts`: new test "FOR ALL ENTRIES, empty driving table selects all rows" (compares against a plain `SELECT *`, checks `sy-dbcnt`).

`packages/transpiler` suite and all `FOR ALL ENTRIES` tests in `test/database.ts` pass locally on sqlite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J7JpA3TGT48zBoix3Ut88s
