### PR TITLE
Function module parameters named like JavaScript keywords (RETURN on every BAPI)

### DIFF
--- a/packages/transpiler/src/structures/function_module.ts
+++ b/packages/transpiler/src/structures/function_module.ts
@@ -56,17 +56,17 @@ export class FunctionModuleTranspiler implements IStructureTranspiler {
         direction = "importing";
       }
       // note: all directions are optional
-      let name = p.name.toLowerCase();
-      if (traversal.options?.keywords?.some(a => a === name)) {
-        name += "_";
-      }
-      ret += `let ${name} = INPUT.${direction}?.${name};\n`;
+      const name = p.name.toLowerCase();
+      // a parameter named like a JavaScript keyword, RETURN on every BAPI,
+      // is declared the way the function body refers to it
+      const variable = Traversal.prefixVariable(name);
+      ret += `let ${variable} = INPUT.${direction}?.${name};\n`;
 
       const type = scope?.findVariable(name)?.getType();
       if (type !== undefined && p.optional === true) {
         // todo, set DEFAULT value
-        ret += `if (${name} === undefined) {
-  ${name} = ${TranspileTypes.toType(type)};
+        ret += `if (${variable} === undefined) {
+  ${variable} = ${TranspileTypes.toType(type)};
 }\n`;
       }
 

--- a/test/unit.ts
+++ b/test/unit.ts
@@ -2574,6 +2574,138 @@ ENDFUNCTION.`;
     await dumpNrun(files, false);
   });
 
+  it("test-56-keyword-parameters", async () => {
+    // function module parameters named like JavaScript keywords, RETURN on every BAPI
+
+    const clas = `CLASS zcl_fugr_kw DEFINITION PUBLIC FINAL CREATE PUBLIC.
+  PUBLIC SECTION.
+ENDCLASS.
+
+CLASS zcl_fugr_kw IMPLEMENTATION.
+ENDCLASS.`;
+
+    const tests = `CLASS ltcl_test DEFINITION FOR TESTING DURATION SHORT RISK LEVEL HARMLESS FINAL.
+  PRIVATE SECTION.
+    METHODS test FOR TESTING.
+    METHODS optional_default FOR TESTING.
+ENDCLASS.
+
+CLASS ltcl_test IMPLEMENTATION.
+
+  METHOD test.
+    DATA lv_result TYPE i.
+
+    CALL FUNCTION 'ZFUGRKW_CALC'
+      EXPORTING
+        delete = 41
+      IMPORTING
+        return = lv_result.
+
+    ASSERT lv_result = 42.
+  ENDMETHOD.
+
+  METHOD optional_default.
+    DATA lv_result TYPE i.
+
+    CALL FUNCTION 'ZFUGRKW_CALC'
+      IMPORTING
+        return = lv_result.
+
+    ASSERT lv_result = 1.
+  ENDMETHOD.
+
+ENDCLASS.`;
+
+    const top = `FUNCTION-POOL zfugrkw.`;
+
+    const topxml = `<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <PROGDIR>
+    <NAME>LZFUGRKWTOP</NAME>
+    <SUBC>I</SUBC>
+    <UCCHECK>X</UCCHECK>
+   </PROGDIR>
+  </asx:values>
+ </asx:abap>
+</abapGit>`;
+
+    const sapl = `
+  INCLUDE LZFUGRKWTOP.
+  INCLUDE LZFUGRKWUXX.`;
+
+    const saplxml = `<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <PROGDIR>
+    <NAME>SAPLZFUGRKW</NAME>
+    <SUBC>F</SUBC>
+    <UCCHECK>X</UCCHECK>
+   </PROGDIR>
+  </asx:values>
+ </asx:abap>
+</abapGit>`;
+
+    const fugrxml = `<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_FUGR" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <AREAT>test</AREAT>
+   <INCLUDES>
+    <SOBJ_NAME>LZFUGRKWTOP</SOBJ_NAME>
+    <SOBJ_NAME>SAPLZFUGRKW</SOBJ_NAME>
+   </INCLUDES>
+   <FUNCTIONS>
+    <item>
+     <FUNCNAME>ZFUGRKW_CALC</FUNCNAME>
+     <SHORT_TEXT>keyword parameters</SHORT_TEXT>
+     <IMPORT>
+      <RSIMP>
+       <PARAMETER>DELETE</PARAMETER>
+       <OPTIONAL>X</OPTIONAL>
+       <TYP>I</TYP>
+      </RSIMP>
+     </IMPORT>
+     <EXPORT>
+      <RSEXP>
+       <PARAMETER>RETURN</PARAMETER>
+       <TYP>I</TYP>
+      </RSEXP>
+     </EXPORT>
+    </item>
+   </FUNCTIONS>
+  </asx:values>
+ </asx:abap>
+</abapGit>`;
+
+    const calc = `FUNCTION zfugrkw_calc.
+*"----------------------------------------------------------------------
+*"*"Local Interface:
+*"  IMPORTING
+*"     REFERENCE(DELETE) TYPE  I OPTIONAL
+*"  EXPORTING
+*"     VALUE(RETURN) TYPE  I
+*"----------------------------------------------------------------------
+
+  return = delete + 1.
+
+ENDFUNCTION.`;
+
+    const files = [
+      {filename: "zcl_fugr_kw.clas.abap", contents: clas},
+      {filename: "zcl_fugr_kw.clas.testclasses.abap", contents: tests},
+      {filename: "zfugrkw.fugr.lzfugrkwtop.abap", contents: top},
+      {filename: "zfugrkw.fugr.lzfugrkwtop.xml", contents: topxml},
+      {filename: "zfugrkw.fugr.saplzfugrkw.abap", contents: sapl},
+      {filename: "zfugrkw.fugr.saplzfugrkw.xml", contents: saplxml},
+      {filename: "zfugrkw.fugr.xml", contents: fugrxml},
+      {filename: "zfugrkw.fugr.zfugrkw_calc.abap", contents: calc},
+    ];
+    await dumpNrun(files, false);
+  });
+
   it("test-57", async () => {
     // check private SETUP method is called
 


### PR DESCRIPTION
A function module parameter called \`RETURN\` (every BAPI has one, e.g. \`BAPI_TRANSACTION_COMMIT\`) transpiled to

\`\`\`js
let return = INPUT.importing?.return;
\`\`\`

a \`SyntaxError: Unexpected strict mode reserved word\` when the generated function group module loads. Same for \`DELETE\`, \`CLASS\`, \`NEW\` and the other names in \`keywords.ts\`.

The function body already refers to such variables through \`Traversal.prefixVariable\` (\`$return\`), so the signature now declares them the same way; the \`INPUT\` property keeps the ABAP name, so callers are unaffected. The previous check against \`options.keywords\` appended \`_\` to a name the body never used.

Test: \`test-56-keyword-parameters\` in \`test/unit.ts\`, a function group with parameters \`DELETE\` (optional) and \`RETURN\`, called from ABAP Unit with and without the optional one. Fails before the fix with the error above.

Found while adding \`BAPI_TRANSACTION_COMMIT\` to open-abap-core.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GU3xTpNL1QDbNkGzuZ4pqg