### PR TITLE
Escape the two reserved words the keyword list still misses: case and with

### DIFF
--- a/packages/transpiler/src/keywords.ts
+++ b/packages/transpiler/src/keywords.ts
@@ -17,5 +17,9 @@ export const DEFAULT_KEYWORDS = new Set<string>([
   "throw",	"throws", "transient", "true",
   "try",	"typeof", "var", "void",
   "delete",
-  "volatile",	"while", "yield"]);
-// "with"
+  "volatile",	"while", "yield",
+// both produce a SyntaxError in the emitted module: they are reserved words
+// in JavaScript and legal ABAP names. "super" is NOT in this list on purpose -
+// the emitted code uses the JS `super` for ABAP's `super->method( )`, and
+// escaping it turns that call into `$super.get().method()`
+  "case", "with"]);

--- a/test/keywords.ts
+++ b/test/keywords.ts
@@ -136,4 +136,21 @@ START-OF-SELECTION.
     expect(abap.console.get()).to.equal("0");
   });
 
+  it("with, case", async () => {
+    // both are reserved in JavaScript and legal as ABAP names, so the emitted
+    // `let with = ...` is a SyntaxError rather than a wrong value
+    const code = `
+DATA with TYPE i.
+DATA case TYPE i.
+with = 1.
+case = 2.
+WRITE with.
+WRITE case.`;
+
+    const js = await run(code);
+    const f = new AsyncFunction("abap", js);
+    await f(abap);
+    expect(abap.console.get()).to.equal("12");
+  });
+
 });


### PR DESCRIPTION
`DEFAULT_KEYWORDS` renames an ABAP identifier that collides with a JavaScript
reserved word — 57 of them today. Two are missing, and both are legal ABAP
names, so the emitted module is not valid JavaScript rather than merely odd:

```abap
DATA with TYPE i.
```

```js
let with = INPUT?.with;
// SyntaxError: Unexpected strict mode reserved word
```

`return`, `in`, `class`, `for`, `delete`, `var`, `new`, `let` and `function`
are all escaped correctly to `$return`, `$in` and so on — `with` and `case`
come out raw. With the two added, the same source emits `$with` and `$case`,
and the module parses.

### Why `super` is not in this list

`super` is reserved in JavaScript and a legal ABAP name too, so it looks like
it belongs here. It does not: the emitted code uses the JavaScript `super` for
ABAP's `super->method( )`, and escaping the word rewrites that call into
`$super.get().method()`. An earlier version of this change included it and the
suite came back with 134 failures across inheritance, class structure and the
database tests. The comment added next to the entries records that, because
the next person reading the list will ask the same question.

### Why `with` was sitting commented out

It was not forgotten — `// "with"` sits at the end of the list. No reason for
it is recorded anywhere in this repository's history; the file arrives whole
in the import commit. If there is one, it belongs next to the entry rather
than in a comment that only repeats the word, so this change moves it into the
set. Happy to restore it if someone knows the reason.

### Where this came from

The consumer side. abap2UI5 has a public method whose importing parameter is
called `with`; its transpiled build went red, and the workaround was to add
the word to that project's own `keywords` option — a per-project list of the
words that project happened to trip over, which is the thing this list exists
to make unnecessary.

### Testing

`test/keywords.ts` covers both through a `WRITE` of each.

- Full suite: 2222 passing, 30 pending. The 127 failures are all
  `ECONNREFUSED 127.0.0.1:5432` from running without `npm run docker:start`;
  none of them is anything but that.
- `npm run lint` clean.
- Negative control: with the two words removed again from the build the tests
  load, the new test fails with `SyntaxError: Unexpected token 'with'`, so it
  is testing the escaping and not just a value.